### PR TITLE
Moving to memset instead of a raw loop massively improves performance.

### DIFF
--- a/src/main/c/java_2_times_faster_than_c.c
+++ b/src/main/c/java_2_times_faster_than_c.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <math.h>
 
 const int  MAX_PAYLOAD_SIZE   = 10000;
@@ -47,9 +48,8 @@ Node *new_node(long id) {
   node->id = id;
   node->size = size;
   node->payload = malloc(sizeof(char) * size);
-  for (int i = 0; i < size; i++) {
-    node->payload[i] = charId;
-  }
+	memset(node->payload, charId, size);
+
   return node;
 }
 


### PR DESCRIPTION
So in new_node there is a raw loop writing a single int value, this is exactly what the memset function does, except it goes brrrrr and raw loops do not :)

On my machine it runs 5 seconds faster than the java version.